### PR TITLE
Implement avoids

### DIFF
--- a/Custom/Scripts/HaremLife/AnimationPoser/Internal/HaremLife_AnimationPoserCore.cs
+++ b/Custom/Scripts/HaremLife/AnimationPoser/Internal/HaremLife_AnimationPoserCore.cs
@@ -836,12 +836,10 @@ namespace HaremLife
 					// all states no longer allowed because of avoids
 					// need to fall back to another state
 					// this does work (I tested it) but is this the best way? other suggestions?
-					List<string> possibleStates = myCurrentLayer.myStates.Keys.ToList();
-					possibleStates.Sort();
-					if(myCurrentLayer.myStates.Count > 0) {
-						State state;
-						myCurrentLayer.myStates.TryGetValue(possibleStates[0], out state);
-						return state;
+					foreach (var s in myCurrentLayer.myStates) {
+						State state = s.Value;
+						if(!state.myAvoid)
+							return state;
 					}
 				}
 

--- a/Custom/Scripts/HaremLife/AnimationPoser/Internal/HaremLife_AnimationPoserCore.cs
+++ b/Custom/Scripts/HaremLife/AnimationPoser/Internal/HaremLife_AnimationPoserCore.cs
@@ -812,8 +812,19 @@ namespace HaremLife
 					}
 				}
 
-				if(states.Count == 0) {
+				if(states.Count == 0 && reachableStates.Count == 0) {
 					return null;
+				} else if(states.Count == 0 && reachableStates.Count > 0) {
+					// all states no longer allowed because of avoids
+					// need to fall back to another state
+					// this does work (I tested it) but is this the best way? other suggestions?
+					List<string> possibleStates = myCurrentLayer.myStates.Keys.ToList();
+					possibleStates.Sort();
+					if(myCurrentLayer.myStates.Count > 0) {
+						State state;
+						myCurrentLayer.myStates.TryGetValue(possibleStates[0], out state);
+						return state;
+					}
 				}
 
 				float sum = 0.0f;

--- a/Custom/Scripts/HaremLife/AnimationPoser/Internal/HaremLife_AnimationPoserCore.cs
+++ b/Custom/Scripts/HaremLife/AnimationPoser/Internal/HaremLife_AnimationPoserCore.cs
@@ -615,6 +615,7 @@ namespace HaremLife
 			public float myDurationNoise = 0.0f;
 			public Dictionary<Layer, State> mySyncTargets = new Dictionary<Layer, State>();
 			public Dictionary<Role, String> myMessages = new Dictionary<Role, String>();
+			public Dictionary<Role, String> myAvoids = new Dictionary<Role, String>();
 
 
 			public Transition(State sourceState, State targetState)
@@ -647,6 +648,7 @@ namespace HaremLife
 				myDurationNoise = t.myDurationNoise;
 				mySyncTargets = t.mySyncTargets;
 				myMessages = t.myMessages;
+				myAvoids = t.myAvoids;
 			}
 
 			public void SendMessages() {
@@ -662,6 +664,22 @@ namespace HaremLife
 					// if (ReferenceEquals(storable, _plugin)) continue;
 					if (!storable.enabled) continue;
 					storable.SendMessage(nameof(AnimationPoser.ReceiveMessage), message);
+				}
+			}
+
+			public void SendAvoids() {
+				foreach(var a in myAvoids) {
+					Role role = a.Key;
+					String avoid = a.Value;
+					Atom person = role.myPerson;
+					if (person == null) continue;
+					var storableId = person.GetStorableIDs().FirstOrDefault(id => id.EndsWith("HaremLife.AnimationPoser"));
+					if (storableId == null) continue;
+					MVRScript storable = person.GetStorableByID(storableId) as MVRScript;
+					if (storable == null) continue;
+					// if (ReferenceEquals(storable, _plugin)) continue;
+					if (!storable.enabled) continue;
+					storable.SendMessage(nameof(AnimationPoser.ReceiveAvoid), avoid);
 				}
 			}
 

--- a/Custom/Scripts/HaremLife/AnimationPoser/Internal/HaremLife_AnimationPoserCore.cs
+++ b/Custom/Scripts/HaremLife/AnimationPoser/Internal/HaremLife_AnimationPoserCore.cs
@@ -797,7 +797,14 @@ namespace HaremLife
 					for(int i=0; i<keys.Count(); i++) {
 						State thisState = keys[i];
 
-						List<State> reachable = thisState.getDirectlyReachableStates();
+						List<State> states = thisState.getDirectlyReachableStates();
+						List<State> reachable = new List<State>();
+						foreach (var s in states) {
+							if(!s.myAvoid) {
+								reachable.Add(s);
+							}
+						}
+
 						for(int j=0; j<reachable.Count(); j++) {
 							State state = reachable[j];
 

--- a/Custom/Scripts/HaremLife/AnimationPoser/Internal/HaremLife_AnimationPoserCore.cs
+++ b/Custom/Scripts/HaremLife/AnimationPoser/Internal/HaremLife_AnimationPoserCore.cs
@@ -322,7 +322,10 @@ namespace HaremLife
 				myCurrentState = state;
 
 				myClock = 0.0f;
-				myDuration = UnityEngine.Random.Range(state.myWaitDurationMin, state.myWaitDurationMax);
+				if(!myPaused)
+					myDuration = UnityEngine.Random.Range(state.myWaitDurationMin, state.myWaitDurationMax);
+				else
+					myDuration = 0.0f;
 
 				if (myMainLayer.val == myName) {
 					myMainState.valNoCallback = myCurrentState.myName;

--- a/Custom/Scripts/HaremLife/AnimationPoser/Internal/HaremLife_AnimationPoserIO.cs
+++ b/Custom/Scripts/HaremLife/AnimationPoser/Internal/HaremLife_AnimationPoserIO.cs
@@ -44,6 +44,7 @@ namespace HaremLife
 
 			SaveRoles(jc);
 			SaveMessages(jc);
+			SaveAvoids(jc);
 			jc["Animations"] = anims;
 
 			return jc;
@@ -65,6 +66,15 @@ namespace HaremLife
 				mlist.Add("", SaveMessage(mm.Value));
 			}
 			jc["Messages"] = mlist;
+		}
+
+		private void SaveAvoids(JSONClass jc) {
+			JSONArray alist = new JSONArray();
+			foreach(var aa in myAvoids)
+			{
+				alist.Add("", SaveAvoid(aa.Value));
+			}
+			jc["Avoids"] = alist;
 		}
 
 		private JSONClass SaveAnimation(Animation animationToSave)
@@ -112,6 +122,25 @@ namespace HaremLife
 			m["TargetAnimation"] = messageToSave.myTargetState.myAnimation().myName;
 
 			return m;
+		}
+
+		private JSONClass SaveAvoid(Avoid avoidToSave) {
+			JSONClass a = new JSONClass();
+
+			a["Name"] = avoidToSave.myName;
+			a["AvoidString"] = avoidToSave.myAvoidString;
+
+			JSONArray avstlist = new JSONArray();
+			foreach(var avst in avoidToSave.myAvoidStates) {
+				JSONClass av = new JSONClass();
+				av["AnimationName"] = avst.Value.myLayer.myAnimation.myName;
+				av["LayerName"] = avst.Value.myLayer.myName;
+				av["StateName"] = avst.Value.myName;
+				avstlist.Add(av);
+			}
+			a["AvoidStates"] = avstlist;
+
+			return a;
 		}
 
 		private JSONClass SaveLayer(Layer layerToSave)
@@ -354,6 +383,7 @@ namespace HaremLife
 				myMainState.setCallbackFunction(myCurrentState.myName);
 			}
 			LoadMessages(jc);
+			LoadAvoids(jc);
 		}
 
 		private Animation LoadAnimation(JSONClass anim)
@@ -697,6 +727,32 @@ namespace HaremLife
 				message.myTargetState = target;
 
 				myMessages[message.myName] = message;
+			}
+		}
+
+		private void LoadAvoids(JSONClass jc)
+		{
+			JSONArray alist = jc["Avoids"].AsArray;
+
+			for (int i=0; i<alist.Count; ++i)
+			{
+				JSONClass aclass = alist[i].AsObject;
+
+				Avoid avoid = new Avoid(aclass["Name"]);
+				avoid.myAvoidString = aclass["AvoidString"];
+
+				JSONArray avstlist = aclass["AvoidStates"].AsArray;
+				for (int j=0; j<avstlist.Count; ++j)
+				{
+					JSONClass av = avstlist[j].AsObject;
+					Animation avan = myAnimations[av["AnimationName"]];
+					Layer avly = avan.myLayers[av["LayerName"]];
+					State avst = avly.myStates[av["StateName"]];
+					string qualStateName = $"{avan.myName}.{avly.myName}.{avst.myName}";
+					avoid.myAvoidStates[qualStateName] = avst;
+				}
+
+				myAvoids[avoid.myName] = avoid;
 			}
 		}
     }

--- a/Custom/Scripts/HaremLife/AnimationPoser/Internal/HaremLife_AnimationPoserUI.cs
+++ b/Custom/Scripts/HaremLife/AnimationPoser/Internal/HaremLife_AnimationPoserUI.cs
@@ -46,6 +46,7 @@ namespace HaremLife
 		private JSONStorableStringChooser mySourceStateList;
 		private JSONStorableStringChooser myTargetStateList;
 		private JSONStorableStringChooser mySyncRoleList;
+		private JSONStorableStringChooser myAvoidRoleList;
 		private JSONStorableStringChooser mySyncLayerList;
 		private JSONStorableStringChooser mySyncStateList;
 		private JSONStorableStringChooser myRoleList;
@@ -1284,6 +1285,41 @@ namespace HaremLife
 					);
 
 					CreateMenuTextInput("Message string", message, false);
+				}
+
+				myAvoidRoleList = CreateDropDown(
+					CastDict(myRoles).ToDictionary(entry => (string)entry.Key, entry => (AnimationObject)entry.Value),
+					myAvoidRoleList,
+					"Send Avoid To Role"
+				);
+
+				CreateMenuSpacer(10, false);
+				CreateMenuInfoOneLine("<size=30><b>Avoids</b></size>", false);
+				CreateMenuInfo("Use this to send avoids to plugin instances in other person atoms when the transition finishes.", 100, false);
+
+				CreateMenuPopup(myAvoidRoleList, false);
+
+				Role selectedAvoidRole;
+				myRoles.TryGetValue(myAvoidRoleList.val, out selectedAvoidRole);
+
+				if(myAvoidRoleList.val != "") {
+					String avoidString;
+					transition.myAvoids.TryGetValue(selectedAvoidRole, out avoidString);
+					if(avoidString == null) {
+						avoidString = "";
+					}
+					JSONStorableString avoid = new JSONStorableString("Avoid String",
+						avoidString, (String aString) => {
+							if(aString == "") {
+								transition.myAvoids.Remove(selectedAvoidRole);
+							} else {
+								transition.myAvoids[selectedAvoidRole] = aString;
+							}
+							UIRefreshMenu();
+						}
+					);
+
+					CreateMenuTextInput("Avoid string", avoid, false);
 				}
 
 				CreateMenuInfoOneLine("<size=30><b>Transition Settings</b></size>", true);

--- a/Custom/Scripts/HaremLife/AnimationPoser/Internal/HaremLife_AnimationPoserUI.cs
+++ b/Custom/Scripts/HaremLife/AnimationPoser/Internal/HaremLife_AnimationPoserUI.cs
@@ -38,6 +38,7 @@ namespace HaremLife
 		private JSONStorableFloat myAnchorBlendRatio;
 		private JSONStorableFloat myAnchorDampingTime;
 		private JSONStorableStringChooser myMessageList;
+		private JSONStorableStringChooser myAvoidList;
 		private JSONStorableStringChooser myTargetAnimationList;
 		private JSONStorableStringChooser myTargetLayerList;
 		private JSONStorableStringChooser mySourceAnimationList;
@@ -49,6 +50,9 @@ namespace HaremLife
 		private JSONStorableStringChooser mySyncStateList;
 		private JSONStorableStringChooser myRoleList;
 		private JSONStorableStringChooser myPersonList;
+		private JSONStorableStringChooser myAvoidAnimationList;
+		private JSONStorableStringChooser myAvoidLayerList;
+		private JSONStorableStringChooser myAvoidStateList;
 		private JSONStorableBool myOptionsDefaultToWorldAnchor;
 		private JSONStorableBool myDebugShowInfo;
 		private JSONStorableBool myDebugShowPaths;
@@ -85,7 +89,8 @@ namespace HaremLife
 		private const int MENU_ANCHORS     = 6;
 		private const int MENU_ROLES	   = 7;
 		private const int MENU_MESSAGES    = 8;
-		private const int MENU_OPTIONS     = 9;
+		private const int MENU_AVOIDS    = 9;
+		private const int MENU_OPTIONS     = 10;
 
 		private GameObject myLabelWith2BXButtonPrefab;
 		private GameObject myLabelWithMXButtonPrefab;
@@ -238,7 +243,7 @@ namespace HaremLife
 			// switch to the desired tab
 			UISelectMenu(tabIdx);
 		}
-		
+
 		private RectTransform InitBasicRectTransformPrefab(string prefabName, Transform initTransform, Transform instTransform, float[] coordsArray, bool initialCast = true)
 		{
 			RectTransform myTransform = Instantiate(initTransform as RectTransform, instTransform);
@@ -417,7 +422,7 @@ namespace HaremLife
 				yield return entry;
 			}
 		}
-		
+
 		private List<string> GetAvailableOptions(
 			Dictionary<string, AnimationObject> myAnimationObjects,
 			bool singleChoice = false,
@@ -457,7 +462,7 @@ namespace HaremLife
 
 			return myAnimationObjectList;
 		}
-		
+
 		private JSONStorableStringChooser CreateDropDown(
 			Dictionary<string, AnimationObject> myAnimationObjects,
 			JSONStorableStringChooser myAnimationObjectList,
@@ -570,6 +575,7 @@ namespace HaremLife
 				case MENU_ANCHORS:     CreateAnchorsMenu();     break;
 				case MENU_ROLES:       CreateRolesMenu();       break;
 				case MENU_MESSAGES:    CreateMessagesMenu();    break;
+				case MENU_AVOIDS:      CreateAvoidsMenu();      break;
 				case MENU_OPTIONS:     CreateOptionsMenu();     break;
 				case MENU_PLAY:        CreatePlayMenu();        break;
 			}
@@ -631,7 +637,7 @@ namespace HaremLife
 			CreateMenuPopup(myMainState, true);
 			CreateMenuSpacer(172, true);
 
-			CreateTabs(new string[] { "Play", "Animations", "Layers", "States", "Transitions", "Triggers", "Anchors", "Roles", "Messages", "Options" });
+			CreateTabs(new string[] { "Play", "Animations", "Layers", "States", "Transitions", "Triggers", "Anchors", "Roles", "Messages", "Avoids", "Options" });
 
 		}
 
@@ -1244,7 +1250,7 @@ namespace HaremLife
 
 			if(baseTransition != null && baseTransition is Transition) {
 				Transition transition = baseTransition as Transition;
-				
+
 				mySyncRoleList = CreateDropDown(
 					CastDict(myRoles).ToDictionary(entry => (string)entry.Key, entry => (AnimationObject)entry.Value),
 					mySyncRoleList,
@@ -1800,6 +1806,122 @@ namespace HaremLife
 			}
 		}
 
+		private void CreateAvoidsMenu()
+		{
+			CreateMenuInfoOneLine("<size=30><b>Avoids</b></size>", false);
+
+			CreateMenuInfo("Use this to define special exclusion of states while toggled on.", 100, false);
+
+			CreateLoadButton("Load Avoids", UILoadAvoidsJSON, false, "Avoids");
+			CreateMenuButton("Save Avoids", UISaveJSONDialog(UISaveAvoidsJSON, "Avoids"), false);
+
+			List<string> avoids = new List<string>();
+			foreach (var a in myAvoids)
+			{
+				Avoid avoid = a.Value;
+				avoids.Add(avoid.myName);
+			}
+			avoids.Sort();
+
+			string selectedAvoidName;
+			if (avoids.Count == 0)
+				selectedAvoidName = "";
+			else if(myAvoidList != null && avoids.Contains(myAvoidList.val))
+				selectedAvoidName = myAvoidList.val;
+			else
+				selectedAvoidName = avoids[0];
+
+			myAvoidList = new JSONStorableStringChooser("Avoid", avoids, selectedAvoidName, "Avoid");
+			myAvoidList.setCallbackFunction += (string v) => UIRefreshMenu();
+
+			CreateMenuPopup(myAvoidList, false);
+
+			CreateMenuButton("Add Avoid", UIAddAvoid, false);
+			CreateMenuButton("Remove Avoid", UIRemoveAvoid, false);
+
+			Avoid selectedAvoid;
+			myAvoids.TryGetValue(selectedAvoidName, out selectedAvoid);
+
+			if(selectedAvoid == null) {
+				return;
+			}
+
+			JSONStorableString avoidName = new JSONStorableString("Avoid Name",
+				selectedAvoid.myName, (String newName) => {
+					myAvoids.Remove(selectedAvoid.myName);
+					selectedAvoid.myName = newName;
+					myAvoids[newName] = selectedAvoid;
+					UIRefreshMenu();
+				}
+			);
+
+			JSONStorableString avoidString = new JSONStorableString("Avoid String",
+				selectedAvoid.myAvoidString, (String newString) => {
+					selectedAvoid.myAvoidString = newString;
+					UIRefreshMenu();
+				}
+			);
+
+			CreateMenuTextInput("Name", avoidName, false);
+			CreateMenuTextInput("String", avoidString, false);
+
+			myAvoidAnimationList = CreateDropDown(
+				CastDict(myAnimations).ToDictionary(entry => (string)entry.Key, entry => (AnimationObject)entry.Value),
+				myAvoidAnimationList,
+				"Avoid Animation"
+			);
+			Animation avoidAnimation;
+			if(!myAnimations.TryGetValue(myAvoidAnimationList.val, out avoidAnimation)){
+				return;
+			};
+
+			Layer avoidLayer;
+			myAvoidLayerList = CreateDropDown(
+				CastDict(avoidAnimation.myLayers).ToDictionary(entry => (string)entry.Key, entry => (AnimationObject)entry.Value),
+				myAvoidLayerList,
+				"Avoid Layer"
+			);
+			if(!avoidAnimation.myLayers.TryGetValue(myAvoidLayerList.val, out avoidLayer))
+				return;
+
+			myAvoidStateList = CreateDropDown(
+				CastDict(avoidLayer.myStates).ToDictionary(entry => (string)entry.Key, entry => (AnimationObject)entry.Value),
+				myAvoidStateList,
+				"Avoid State"
+			);
+
+			if (myAvoidAnimationList.choices.Count > 0)
+			{
+				CreateMenuPopup(myAvoidAnimationList, false);
+			}
+			if (myAvoidLayerList.choices.Count > 0)
+			{
+				CreateMenuPopup(myAvoidLayerList, false);
+			}
+
+			if (myAvoidStateList.choices.Count > 0)
+			{
+				CreateMenuPopup(myAvoidStateList, false);
+				CreateMenuButton("Add Avoid State", () => {
+					Animation a = myAnimations[myAvoidAnimationList.val];
+					Layer l = a.myLayers[myAvoidLayerList.val];
+					State s = l.myStates[myAvoidStateList.val];
+					string qualStateName = $"{a.myName}.{l.myName}.{s.myName}";
+					selectedAvoid.myAvoidStates[qualStateName] = s;
+					UIRefreshMenu();
+				}, false);
+			}
+			foreach(var s in selectedAvoid.myAvoidStates) {
+				CreateMenuLabelXButton(
+					s.Key,
+					() => {
+						selectedAvoid.myAvoidStates.Remove(s.Key);
+						UIRefreshMenu();
+					}, false
+				);
+			}
+		}
+
 		private void CreateOptionsMenu()
 		{
 			CreateMenuInfoOneLine("<size=30><b>General Options</b></size>", false);
@@ -1838,6 +1960,15 @@ namespace HaremLife
 			JSONClass jc = LoadJSON(url).AsObject;
 			if (jc != null)
 				LoadMessages(jc);
+
+			UIRefreshMenu();
+		}
+
+		private void UILoadAvoidsJSON(string url)
+		{
+			JSONClass jc = LoadJSON(url).AsObject;
+			if (jc != null)
+				LoadAvoids(jc);
 
 			UIRefreshMenu();
 		}
@@ -1925,6 +2056,16 @@ namespace HaremLife
 			path = path.Replace('\\', '/');
 			JSONClass jc = new JSONClass();
 			SaveMessages(jc);
+			SaveJSON(jc, path);
+		}
+
+		private void UISaveAvoidsJSON(string path)
+		{
+			if (string.IsNullOrEmpty(path))
+				return;
+			path = path.Replace('\\', '/');
+			JSONClass jc = new JSONClass();
+			SaveAvoids(jc);
 			SaveJSON(jc, path);
 		}
 
@@ -2233,6 +2374,32 @@ namespace HaremLife
 				myMessageList.val = messages[0];
 			} else {
 				myMessageList.val = "";
+			}
+
+			UIRefreshMenu();
+		}
+
+		private void UIAddAvoid()
+		{
+			string name = FindNewName("Avoid", "avoids", new List<string>(myAvoids.Keys));
+			if (name == null)
+				return;
+
+			myAvoids[name] = new Avoid(name);
+			myAvoidList.val = name;
+			UIRefreshMenu();
+		}
+
+		private void UIRemoveAvoid()
+		{
+			myAvoids.Remove(myAvoidList.val);
+
+			List<string> avoids = myAvoids.Keys.ToList();
+			avoids.Sort();
+			if(avoids.Count > 0) {
+				myAvoidList.val = avoids[0];
+			} else {
+				myAvoidList.val = "";
 			}
 
 			UIRefreshMenu();


### PR DESCRIPTION
Implemented avoids. This includes my other bug fix as well since I branched off of my main code, so I'll close the other PR (again). Currently you can:
- Add an Avoid to a Role that prevents the Role from transitioning to a list of states
  - (Potential room for improvement) If a Role is currently in a state that will be avoided going forward, the state is immediately switched to another, allowed state (somewhat at random -- suggestions here?)
- Send an "avoid message" to a Role to toggle an avoid on or off
  - E.g. if an Avoid name is "TestAvoid", you could send "TestAvoid;0" to turn the avoid off and "TestAvoid;1" to turn it back on
- (Potential room for improvement) If an avoid is on and a message is sent to transition to an avoided state, the message is essentially disregarded