### PR TITLE
Fix animation switch

### DIFF
--- a/Custom/Scripts/HaremLife/AnimationPoser/Internal/HaremLife_AnimationPoserCore.cs
+++ b/Custom/Scripts/HaremLife/AnimationPoser/Internal/HaremLife_AnimationPoserCore.cs
@@ -557,6 +557,9 @@ namespace HaremLife
 					targetLayer.myStateChain.Insert(0, sourceState);
 
 					SetAnimation(animation);
+
+					transition.SendMessages();
+					transition.SendAvoids();
 				} else {
 					List<State> stateChain = new List<State>(2);
 					stateChain.Add(sourceState);

--- a/Custom/Scripts/HaremLife/AnimationPoser/Internal/HaremLife_AnimationPoserCore.cs
+++ b/Custom/Scripts/HaremLife/AnimationPoser/Internal/HaremLife_AnimationPoserCore.cs
@@ -518,6 +518,21 @@ namespace HaremLife
 				myClock = myDuration;
 			}
 
+			public void BlendFromAnimation(State fromState = null) {
+				State blendState = CreateBlendState();
+				if (fromState != null)
+					blendState.AssignOutTriggers(fromState);
+				CaptureState(blendState);
+				myCurrentState = blendState;
+				myDuration = blendState.myWaitDurationMin;
+
+				if (fromState != null)
+					myStateChain = new List<State>(fromState.myLayer.myStateChain);
+				else
+					myStateChain = new List<State>(myStateChain);
+				myStateChain.Insert(0, blendState);
+			}
+
 			public void SetTransition()
 			{
 				myClock = 0.0f;
@@ -541,20 +556,16 @@ namespace HaremLife
 
 					foreach(var l in animation.myLayers) {
 						Layer layer = l.Value;
-						if(layer == targetLayer)
+						if(layer == targetLayer || transition.mySyncTargets.Keys.Contains(layer))
 							continue;
 						layer.GoToAnyState();
 					}
 
-					State blendState = targetLayer.CreateBlendState();
-					targetLayer.CaptureState(blendState);
-					blendState.AssignOutTriggers(myCurrentState);
-					targetLayer.myCurrentState = blendState;
-					targetLayer.myDuration = blendState.myWaitDurationMin;
+					foreach(var sc in transition.mySyncTargets) {
+						sc.Key.BlendFromAnimation();
+					}
 
-					sourceState = blendState;
-					targetLayer.myStateChain = new List<State>(myStateChain);
-					targetLayer.myStateChain.Insert(0, sourceState);
+					targetLayer.BlendFromAnimation(myCurrentState);
 
 					SetAnimation(animation);
 

--- a/Custom/Scripts/HaremLife/AnimationPoser/Internal/HaremLife_AnimationPoserCore.cs
+++ b/Custom/Scripts/HaremLife/AnimationPoser/Internal/HaremLife_AnimationPoserCore.cs
@@ -549,6 +549,8 @@ namespace HaremLife
 					State blendState = targetLayer.CreateBlendState();
 					targetLayer.CaptureState(blendState);
 					blendState.AssignOutTriggers(myCurrentState);
+					targetLayer.myCurrentState = blendState;
+					targetLayer.myDuration = blendState.myWaitDurationMin;
 
 					sourceState = blendState;
 					targetLayer.myStateChain = new List<State>(myStateChain);


### PR DESCRIPTION
There were three issues with switching animations:
1. If done by way of regular transition, messages and avoids were not sent
2. If done either through message or transition, blendstates were created but not set as current state, leading to jumpiness.
3. Synced layers jumped to the last used state before moving to the synced state, leading to jumpiness.

The fixes:
1. Add in the two lines to send avoids and messages.
2. Set the blend state as the current state, and set the duration to 0.
3. Refactored the blendstate creation in 2 into a separate function, BlendFromAnimation. Re-use this for synced layers to put them in a blendstate as well before carrying on to the synced state.